### PR TITLE
js-yaml should be installed a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "js-yaml": "~3.0.1"
+  },
   "devDependencies": {
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.2",
-    "js-yaml": "~3.0.1"
+    "grunt": "~0.4.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.2"


### PR DESCRIPTION
`js-yaml` is a dependency, not a devDependency. Relocating it into the dependencies object in package.json. This allows `js-yaml` to be installed when `grunt-packager` is installed.
