### PR TITLE
grunt-packager was renamed to grunt-mootools-packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-packager
+# grunt-mootools-packager
 
 > Grunt task for MooTools Packager projects.
 
@@ -8,13 +8,13 @@ This plugin requires Grunt `~0.4.2`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-packager --save-dev
+npm install grunt-mootools-packager --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('grunt-packager');
+grunt.loadNpmTasks('grunt-mootools-packager');
 ```
 
 ## The "packager" task


### PR DESCRIPTION
Name update on the Readme file
