### PR TITLE
upgrade definition.package / option.name

### DIFF
--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -66,12 +66,22 @@ module.exports = function(grunt) {
 			// read files and populate registry map
 			files.forEach(function(filepath){
 
+				if (typeof options.name != 'string'){
+
+					var projectName; 
+					for (var prj in options.name) {
+
+						if(~filepath.indexOf(options.name[prj])) projectName = prj;
+					}
+					if (!projectName) projectName = Object.keys(options.name)[0];
+				}			
+
 				var source = grunt.file.read(filepath);
 				var definition = YAML.load(source.match(DESC_REGEXP)[1] || '');
 
 				if (!definition || !validDefinition(definition)) return grunt.log.error('invalid definition: ' + filepath);
 
-				definition.package = options.name;
+				definition.package = projectName || options.name;
 				definition.source = source;
 				definition.key = getPrimaryKey(definition);
 				definition.provides = toArray(definition.provides);


### PR DESCRIPTION
Upgrade to accept multiple Names and use them based on a object with
'package name': 'path'.

This is BC and defaults to first Name. New uses in gruntfile:

```
options: {
    name: {
        More: null,
        Core: 'node_modules/mootools-core/'
    }
},
```

[Tested this]() with my Core repo and got no errors.
