### PR TITLE
Check for yaml bypass

### DIFF
--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -45,9 +45,11 @@ module.exports = function(grunt) {
 			if (included[definition.key]) return;
 			included[definition.key] = true;
 
-			definition.requires.forEach(function(key){
-				resolveDeps(registry[key]);
-			});
+			if (!options.ignoreYAMLheader){
+				definition.requires.forEach(function(key){
+					resolveDeps(registry[key]);
+				});
+			}
 			buffer.push(definition);
 		}
 


### PR DESCRIPTION
The Specs in More have YAML headers with provides/requires. Since compiling source files for More/Core and Specs are different tasks, this PR will make possible a option in the gruntfile so the YAML dependencies can be
ignored.

Related: `https://github.com/mootools/mootools-more/pull/1237`
