### PR TITLE
Various improvements around dependency resolution; better logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,96 @@ Default value: `false`
 
 A single, or multiple, strings or regexp to remove from the combined code.
 
-#### options.name
+#### options.separator
 Type: `String`
+Default value: `grunt.util.linefeed`
+
+The delimeter to join all the source files together.
+
+#### options.name
+Type: `String` or `Object`
 
 The package name. TODO: Use package.json.
 
-### Usage Examples
+The name of the package, or, if there are multiple packages being built, an
+object with the names and paths to their source files.
+
+```js
+grunt.initConfig({
+  packager: {
+    options: {
+      name: {
+        Core: 'js/mootools-core',
+        More: 'js/mootools-more'
+      }
+    },
+    all: {
+      'dest/mootools.js': 'Source/**.js',
+    },
+  },
+});
+```
+
+
+#### options.ignoreYAMLheader
+Type: `Booelan`
+Default value: `false`
+
+Ignores the YAML headers for dependency loading.
+
+#### options.only
+Type: `Array`
+
+The specific components or packages to compile (with their dependencies).
+
+NOTE: You can specify the `.only` value in the `.options` and it will apply to all
+configurations globally, but you can also specify an `.only` value for each configuration.
+This allows you to build numerous libraries with specific requirements.
+
+```js
+grunt.initConfig({
+  packager: {
+    options: {
+      name: {
+        Core: 'js/mootools-core',
+        More: 'js/mootools-more'
+      }
+    },
+    // all of both libraries
+    all: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      dest: 'mootools.js'
+    },
+    // the Form.Validator component and its requirements
+    formValidator: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      only: [
+        'More/Form.Validator'
+      ]
+      dest: 'form.validator.js'
+    },
+    // all of the More package and its requirements
+    allOfMore: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      only: [
+        'More/*'
+      ]
+      dest: 'more.js'
+    }
+  },
+});
+```
+
+### Other Usage Examples
 
 #### Default Options
 ```js

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -15,11 +15,14 @@ module.exports = function(grunt) {
 	var DESC_REGEXP = /\/\*\s*^---([.\s\S]*)^(?:\.\.\.|---)\s*\*\//m;
 	var SL_STRIP_EXP = ['\\/[\\/*]\\s*<', '>(.*?)<\\/', '>(?:\\s*\\*\\/)?'];
 	var ML_STRIP_EXP = ['\\/[\\/*]\\s*<', '>([.\\s\\S]*?)<\\/', '>(?:\\s*\\*\\/)?'];
+	var PACKAGE_DOT_STAR = /(.*)\/\*$/;
 
-	function validDefinition(object) {
-		return 'name' in object && 'provides' in object;
+	// ensures the definition has a name and a provision
+	function validDefinition(definition) {
+		return 'name' in definition && 'provides' in definition;
 	}
 
+	// returns primary key of a definition
 	function getPrimaryKey(definition){
 		return definition.package + '/' + definition.name;
 	}
@@ -31,58 +34,95 @@ module.exports = function(grunt) {
 		}).concat(getPrimaryKey(definition));
 	}
 
+	// wraps item in an array if it isn't one
 	function toArray(object){
 		if (!object) return [];
 		if (object.charAt) return [object];
 		return grunt.util.toArray(object);
 	}
 
+	// verifies that an item is in the registry of components
+	function checkRegistry(registry, key, path){
+		if (registry[key] == undefined){
+			throw new Error('Dependency not found: ' + key + ' in ' + path);
+		}
+	}
+
+	// fixes requires keys to use package/key; allows for dependencies that
+	// use the `/Key` or just `Key` convention to refer to a component within
+	// the same package
+	function fixDependencyKey(key, packageName){
+		// support `requires: /SomethingInThisPackage`
+		if (key.indexOf('/') == 0) key = packageName + key;
+		// support `requires: SomethingInThisPackage`
+		if (key.indexOf('/') == -1) key = packageName + '/' + key;
+		return key;
+	}
+
 	grunt.registerMultiTask('packager', 'Grunt task for MooTools Packager projects.', function() {
 
-		var registry = {}, buffer = [], included = {}, set = [];
+		var registry = {}, buffer = [], included = {}, set = [], packages = {};
+
+		var options = this.options({
+			only: false,
+			strip: [],
+			separator: grunt.util.linefeed,
+			ignoreYAMLheader: false
+		});
+
 
 		function resolveDeps(definition){
+			definition.key = fixDependencyKey(definition.key);
 			if (included[definition.key]) return;
+			grunt.verbose.writeln('|-', definition.key);
 			included[definition.key] = true;
 
 			if (!options.ignoreYAMLheader){
 				definition.requires.forEach(function(key){
+					key = fixDependencyKey(key, definition.package);
+					checkRegistry(registry, key, definition.filepath);
 					resolveDeps(registry[key]);
 				});
 			}
 			buffer.push(definition);
 		}
 
-		var options = this.options({
-			only: false,
-			strip: [],
-			separator: grunt.util.linefeed
-		});
+		// loads a component and its dependencies
+		// if the key given is a package and a wildcard, loads all of them
+		// e.g. `Package/Component` OR `Package/*`
+		var loadComponent = function(key){
+			var wildCardMatch = key.match(PACKAGE_DOT_STAR);
+			if (wildCardMatch){
+				packages[wildCardMatch[1]].forEach(loadComponent);
+			} else {
+				if (key in registry) resolveDeps(registry[key]);
+				else throw new Error('Missing key: ' + key);
+			}
+		}
 
 		this.files.forEach(function(f){
 			// expand and filter by existence
 			var files = grunt.file.expand({nonull: true}, f.src).filter(function(filepath){
 				return grunt.file.exists(filepath) || grunt.log.warn('empty or invalid: ' + filepath);
 			});
-
 			// read files and populate registry map
 			files.forEach(function(filepath){
 
 				if (typeof options.name != 'string'){
 
-					var projectName; 
+					var projectName;
 					for (var prj in options.name) {
 
 						if(~filepath.indexOf(options.name[prj])) projectName = prj;
 					}
 					if (!projectName) projectName = Object.keys(options.name)[0];
-				}			
+				}
 
 				var source = grunt.file.read(filepath);
 				var definition = YAML.load(source.match(DESC_REGEXP)[1] || '');
 
 				if (!definition || !validDefinition(definition)) return grunt.log.error('invalid definition: ' + filepath);
-
+				definition.filepath = filepath;
 				definition.package = projectName || options.name;
 				definition.source = source;
 				definition.key = getPrimaryKey(definition);
@@ -91,7 +131,6 @@ module.exports = function(grunt) {
 				definition.requires = toArray(definition.requires).map(function(component){
 					return ~component.indexOf('/') ? component : (definition.package + '/' + component);
 				});
-
 				// track all files collected, used to check that all sources were included
 				set.push(definition.key);
 
@@ -104,12 +143,28 @@ module.exports = function(grunt) {
 
 			});
 
-			(options.only ? toArray(options.only) : set).forEach(function(key){
-				if (!(key in registry)) throw new Error('Missing key: ' + key);
-				resolveDeps(registry[key]);
+			set.forEach(function(key){
+				var definition = registry[key];
+				if (!packages[definition.package]) packages[definition.package] = []
+				packages[definition.package].push(key);
 			});
 
+			if (grunt.option('verbose')){
+				grunt.log.verbose.writeln('Loaded packages:')
+				for (var p in packages){
+					grunt.log.verbose.writeln('Package: ', p);
+					grunt.log.verbose.writeln(' ', packages[p])
+				}
+			}
+			// support global options.only as well as .only per build
+			var only = options.only || f.only;
 
+			grunt.log.verbose.writeln('compiling', f.dest, 'with dependencies:', only || 'all');
+
+			// load each component into the buffer list
+			(only ? toArray(only) : set).forEach(loadComponent);
+
+			// convert the buffer into the actual source
 			buffer = buffer.map(function(def){ return def.source; }).join(options.separator);
 
 			// strip blocks
@@ -118,6 +173,8 @@ module.exports = function(grunt) {
 					.replace(RegExp(SL_STRIP_EXP.join(block), 'gm'), '')
 					.replace(RegExp(ML_STRIP_EXP.join(block), 'gm'), '');
 			});
+
+			grunt.log.verbose.ok('successfully compiled', f.dest, 'with dependencies:', only || 'all');
 
 			grunt.file.write(f.dest, buffer);
 		});


### PR DESCRIPTION
- Now fully supports YAML dependency graphs
- Supports components referencing other components in the same package 
  with the `/SomethingInThisPackage` or just `SomethingInThisPackage` 
  convention
- Adds additional `--verbose` logging 
- Adds support for `--show-packages` flag which will list all discovered packages and their components
- Adds support for configurations that use `only: ['PackageName/*']` wildcards to include entire packages
- Improves logging when a package is unable to be resolved in the dependency graph
- Added documentation for various flags and options
