### PR TITLE
Docs, logging and YAML support upgrade

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
         },
         files: {
           'tmp/all.js': 'test/fixtures/*.js',
-        },
+        }
       },
       nocompat_options: {
         options: {
@@ -33,13 +33,45 @@ module.exports = function(grunt) {
         },
         files: {
           'tmp/nocompat.js': 'test/fixtures/*.js',
-        },
+        }
       },
+      multipackage: {
+        options: {
+          name: {
+            ProjectB: 'test/fixtures/Project_B',
+            ProjectA: 'test/fixtures/Project_A'
+          }
+        },
+        src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
+        dest: 'tmp/multipackage.js'
+      },
+      multipackage_partial_simple: {
+        options: {
+          only: ['ProjectA/ProjectA.Secondary'],
+          name: {
+            ProjectB: 'test/fixtures/Project_B',
+            ProjectA: 'test/fixtures/Project_A'
+          }
+        },
+        src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
+        dest: 'tmp/multipackage_partial_simple.js'
+      },
+      multipackage_partial_widcard: {
+        options: {
+          only: 'ProjectB/*',
+          name: {
+            ProjectB: 'test/fixtures/Project_B',
+            ProjectA: 'test/fixtures/Project_A'
+          }
+        },
+        src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
+        dest: 'tmp/multipackage_partial_widcard.js'
+      }
     },
 
     nodeunit: {
       tests: ['test/*_test.js'],
-    },
+    }
 
   });
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,96 @@ Default value: `false`
 
 A single, or multiple, strings or regexp to remove from the combined code.
 
-#### options.name
+#### options.separator
 Type: `String`
+Default value: `grunt.util.linefeed`
+
+The delimeter to join all the source files together.
+
+#### options.name
+Type: `String` or `Object`
 
 The package name. TODO: Use package.json.
 
-### Usage Examples
+The name of the package, or, if there are multiple packages being built, an
+object with the names and paths to their source files.
+
+```js
+grunt.initConfig({
+  packager: {
+    options: {
+      name: {
+        Core: 'js/mootools-core',
+        More: 'js/mootools-more'
+      }
+    },
+    all: {
+      'dest/mootools.js': 'Source/**.js',
+    },
+  },
+});
+```
+
+
+#### options.ignoreYAMLheader
+Type: `Booelan`
+Default value: `false`
+
+Ignores the YAML headers for dependency loading.
+
+#### options.only
+Type: `Array`
+
+The specific components or packages to compile (with their dependencies).
+
+NOTE: You can specify the `.only` value in the `.options` and it will apply to all
+configurations globally, but you can also specify an `.only` value for each configuration.
+This allows you to build numerous libraries with specific requirements.
+
+```js
+grunt.initConfig({
+  packager: {
+    options: {
+      name: {
+        Core: 'js/mootools-core',
+        More: 'js/mootools-more'
+      }
+    },
+    // all of both libraries
+    all: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      dest: 'mootools.js'
+    },
+    // the Form.Validator component and its requirements
+    formValidator: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      only: [
+        'More/Form.Validator'
+      ]
+      dest: 'form.validator.js'
+    },
+    // all of the More package and its requirements
+    allOfMore: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      only: [
+        'More/*'
+      ]
+      dest: 'more.js'
+    }
+  },
+});
+```
+
+### Other Usage Examples
 
 #### Default Options
 ```js

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Default value: `false`
 Ignores the YAML headers for dependency loading.
 
 #### options.only
-Type: `Array`
+Type: `String` or `Array`
 
 The specific components or packages to compile (with their dependencies).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-mootools-packager",
   "description": "Grunt task for MooTools Packager projects.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/ibolmo/grunt-packager",
   "author": {
     "name": "Olmo Maldonado",

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -34,6 +34,17 @@ module.exports = function(grunt) {
 		}).concat(getPrimaryKey(definition));
 	}
 
+	// matches project name with component's path
+	function getProjectName(componentPath, optionsName){
+		if (typeof optionsName == 'string') return optionsName;
+		var projectName;
+		for (var prj in optionsName){
+			if(~componentPath.indexOf(optionsName[prj])) projectName = prj;
+		}
+		if (!projectName) grunt.fail.warn('Missing name in options for component with path: ' + componentPath);
+		return projectName;
+	}
+
 	// wraps item in an array if it isn't one
 	function toArray(object){
 		if (!object) return [];
@@ -108,22 +119,12 @@ module.exports = function(grunt) {
 			// read files and populate registry map
 			files.forEach(function(filepath){
 
-				if (typeof options.name != 'string'){
-
-					var projectName;
-					for (var prj in options.name) {
-
-						if(~filepath.indexOf(options.name[prj])) projectName = prj;
-					}
-					if (!projectName) projectName = Object.keys(options.name)[0];
-				}
-
 				var source = grunt.file.read(filepath);
 				var definition = YAML.load(source.match(DESC_REGEXP)[1] || '');
 
 				if (!definition || !validDefinition(definition)) return grunt.log.error('invalid definition: ' + filepath);
 				definition.filepath = filepath;
-				definition.package = projectName || options.name;
+				definition.package = getProjectName(filepath, options.name);
 				definition.source = source;
 				definition.key = getPrimaryKey(definition);
 				definition.provides = toArray(definition.provides);

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -15,11 +15,14 @@ module.exports = function(grunt) {
 	var DESC_REGEXP = /\/\*\s*^---([.\s\S]*)^(?:\.\.\.|---)\s*\*\//m;
 	var SL_STRIP_EXP = ['\\/[\\/*]\\s*<', '>(.*?)<\\/', '>(?:\\s*\\*\\/)?'];
 	var ML_STRIP_EXP = ['\\/[\\/*]\\s*<', '>([.\\s\\S]*?)<\\/', '>(?:\\s*\\*\\/)?'];
+	var PACKAGE_DOT_STAR = /(.*)\/\*$/;
 
-	function validDefinition(object) {
-		return 'name' in object && 'provides' in object;
+	// ensures the definition has a name and a provision
+	function validDefinition(definition) {
+		return 'name' in definition && 'provides' in definition;
 	}
 
+	// returns primary key of a definition
 	function getPrimaryKey(definition){
 		return definition.package + '/' + definition.name;
 	}
@@ -31,58 +34,95 @@ module.exports = function(grunt) {
 		}).concat(getPrimaryKey(definition));
 	}
 
+	// wraps item in an array if it isn't one
 	function toArray(object){
 		if (!object) return [];
 		if (object.charAt) return [object];
 		return grunt.util.toArray(object);
 	}
 
+	// verifies that an item is in the registry of components
+	function checkRegistry(registry, key, path){
+		if (registry[key] == undefined){
+			throw new Error('Dependency not found: ' + key + ' in ' + path);
+		}
+	}
+
+	// fixes requires keys to use package/key; allows for dependencies that
+	// use the `/Key` or just `Key` convention to refer to a component within
+	// the same package
+	function fixDependencyKey(key, packageName){
+		// support `requires: /SomethingInThisPackage`
+		if (key.indexOf('/') == 0) key = packageName + key;
+		// support `requires: SomethingInThisPackage`
+		if (key.indexOf('/') == -1) key = packageName + '/' + key;
+		return key;
+	}
+
 	grunt.registerMultiTask('packager', 'Grunt task for MooTools Packager projects.', function() {
 
-		var registry = {}, buffer = [], included = {}, set = [];
+		var registry = {}, buffer = [], included = {}, set = [], packages = {};
+
+		var options = this.options({
+			only: false,
+			strip: [],
+			separator: grunt.util.linefeed,
+			ignoreYAMLheader: false
+		});
+
 
 		function resolveDeps(definition){
+			definition.key = fixDependencyKey(definition.key);
 			if (included[definition.key]) return;
+			grunt.verbose.writeln('|-', definition.key);
 			included[definition.key] = true;
 
 			if (!options.ignoreYAMLheader){
 				definition.requires.forEach(function(key){
+					key = fixDependencyKey(key, definition.package);
+					checkRegistry(registry, key, definition.filepath);
 					resolveDeps(registry[key]);
 				});
 			}
 			buffer.push(definition);
 		}
 
-		var options = this.options({
-			only: false,
-			strip: [],
-			separator: grunt.util.linefeed
-		});
+		// loads a component and its dependencies
+		// if the key given is a package and a wildcard, loads all of them
+		// e.g. `Package/Component` OR `Package/*`
+		var loadComponent = function(key){
+			var wildCardMatch = key.match(PACKAGE_DOT_STAR);
+			if (wildCardMatch){
+				packages[wildCardMatch[1]].forEach(loadComponent);
+			} else {
+				if (key in registry) resolveDeps(registry[key]);
+				else throw new Error('Missing key: ' + key);
+			}
+		}
 
 		this.files.forEach(function(f){
 			// expand and filter by existence
 			var files = grunt.file.expand({nonull: true}, f.src).filter(function(filepath){
 				return grunt.file.exists(filepath) || grunt.log.warn('empty or invalid: ' + filepath);
 			});
-
 			// read files and populate registry map
 			files.forEach(function(filepath){
 
 				if (typeof options.name != 'string'){
 
-					var projectName; 
+					var projectName;
 					for (var prj in options.name) {
 
 						if(~filepath.indexOf(options.name[prj])) projectName = prj;
 					}
 					if (!projectName) projectName = Object.keys(options.name)[0];
-				}			
+				}
 
 				var source = grunt.file.read(filepath);
 				var definition = YAML.load(source.match(DESC_REGEXP)[1] || '');
 
 				if (!definition || !validDefinition(definition)) return grunt.log.error('invalid definition: ' + filepath);
-
+				definition.filepath = filepath;
 				definition.package = projectName || options.name;
 				definition.source = source;
 				definition.key = getPrimaryKey(definition);
@@ -91,7 +131,6 @@ module.exports = function(grunt) {
 				definition.requires = toArray(definition.requires).map(function(component){
 					return ~component.indexOf('/') ? component : (definition.package + '/' + component);
 				});
-
 				// track all files collected, used to check that all sources were included
 				set.push(definition.key);
 
@@ -104,12 +143,28 @@ module.exports = function(grunt) {
 
 			});
 
-			(options.only ? toArray(options.only) : set).forEach(function(key){
-				if (!(key in registry)) throw new Error('Missing key: ' + key);
-				resolveDeps(registry[key]);
+			set.forEach(function(key){
+				var definition = registry[key];
+				if (!packages[definition.package]) packages[definition.package] = []
+				packages[definition.package].push(key);
 			});
 
+			if (grunt.option('verbose')){
+				grunt.log.verbose.writeln('Loaded packages:')
+				for (var p in packages){
+					grunt.log.verbose.writeln('Package: ', p);
+					grunt.log.verbose.writeln(' ', packages[p])
+				}
+			}
+			// support global options.only as well as .only per build
+			var only = options.only || f.only;
 
+			grunt.log.verbose.writeln('compiling', f.dest, 'with dependencies:', only || 'all');
+
+			// load each component into the buffer list
+			(only ? toArray(only) : set).forEach(loadComponent);
+
+			// convert the buffer into the actual source
 			buffer = buffer.map(function(def){ return def.source; }).join(options.separator);
 
 			// strip blocks
@@ -118,6 +173,8 @@ module.exports = function(grunt) {
 					.replace(RegExp(SL_STRIP_EXP.join(block), 'gm'), '')
 					.replace(RegExp(ML_STRIP_EXP.join(block), 'gm'), '');
 			});
+
+			grunt.log.verbose.ok('successfully compiled', f.dest, 'with dependencies:', only || 'all');
 
 			grunt.file.write(f.dest, buffer);
 		});

--- a/test/expected/multipackage.js
+++ b/test/expected/multipackage.js
@@ -1,0 +1,51 @@
+/*
+---
+
+name: Main
+
+description: Provides projectA.
+
+provides: [ProjectA, ProjectA.Fn]
+
+...
+*/
+
+var projectA = {};
+projectA.Fn = function(){
+	return 'ProjectA';
+};
+projectA.name = ['Main'];
+
+/*
+---
+
+name: Secondary
+
+description: ProjectA.Secondary, just a small extension
+
+requires: [/ProjectA]
+
+provides: [ProjectA.Secondary]
+
+...
+*/
+
+projectA.name = projectA.name.concat('Secondary');
+
+/*
+---
+
+name: B part of ProjectA
+
+description: ProjectB, extending ProjectA
+
+requires: [ProjectA/ProjectA]
+
+provides: ProjectB
+
+...
+*/
+
+var projectB = function(){
+	return [projectA.name].concat('ProjectB');
+};

--- a/test/expected/multipackage_partial_simple.js
+++ b/test/expected/multipackage_partial_simple.js
@@ -1,0 +1,33 @@
+/*
+---
+
+name: Main
+
+description: Provides projectA.
+
+provides: [ProjectA, ProjectA.Fn]
+
+...
+*/
+
+var projectA = {};
+projectA.Fn = function(){
+	return 'ProjectA';
+};
+projectA.name = ['Main'];
+
+/*
+---
+
+name: Secondary
+
+description: ProjectA.Secondary, just a small extension
+
+requires: [/ProjectA]
+
+provides: [ProjectA.Secondary]
+
+...
+*/
+
+projectA.name = projectA.name.concat('Secondary');

--- a/test/expected/multipackage_partial_widcard.js
+++ b/test/expected/multipackage_partial_widcard.js
@@ -1,0 +1,35 @@
+/*
+---
+
+name: Main
+
+description: Provides projectA.
+
+provides: [ProjectA, ProjectA.Fn]
+
+...
+*/
+
+var projectA = {};
+projectA.Fn = function(){
+	return 'ProjectA';
+};
+projectA.name = ['Main'];
+
+/*
+---
+
+name: B part of ProjectA
+
+description: ProjectB, extending ProjectA
+
+requires: [ProjectA/ProjectA]
+
+provides: ProjectB
+
+...
+*/
+
+var projectB = function(){
+	return [projectA.name].concat('ProjectB');
+};

--- a/test/fixtures/Project_A/ProjectA.Secondary.js
+++ b/test/fixtures/Project_A/ProjectA.Secondary.js
@@ -1,0 +1,15 @@
+/*
+---
+
+name: Secondary
+
+description: ProjectA.Secondary, just a small extension
+
+requires: [/ProjectA]
+
+provides: [ProjectA.Secondary]
+
+...
+*/
+
+projectA.name = projectA.name.concat('Secondary');

--- a/test/fixtures/Project_A/ProjectA.js
+++ b/test/fixtures/Project_A/ProjectA.js
@@ -1,0 +1,17 @@
+/*
+---
+
+name: Main
+
+description: Provides projectA.
+
+provides: [ProjectA, ProjectA.Fn]
+
+...
+*/
+
+var projectA = {};
+projectA.Fn = function(){
+	return 'ProjectA';
+};
+projectA.name = ['Main'];

--- a/test/fixtures/Project_B/ProjectB.js
+++ b/test/fixtures/Project_B/ProjectB.js
@@ -1,0 +1,17 @@
+/*
+---
+
+name: B part of ProjectA
+
+description: ProjectB, extending ProjectA
+
+requires: [ProjectA/ProjectA]
+
+provides: ProjectB
+
+...
+*/
+
+var projectB = function(){
+	return [projectA.name].concat('ProjectB');
+};

--- a/test/packager_test.js
+++ b/test/packager_test.js
@@ -3,8 +3,9 @@
 var grunt = require('grunt');
 
 exports.packager = {
-  default_options: function(test) {
-    return test.done();
+
+  // simple compat build, one project
+  default_options: function(test){ 
     test.expect(1);
 
     var actual = grunt.file.read('tmp/all.js');
@@ -13,7 +14,8 @@ exports.packager = {
 
     test.done();
   },
-  nocompat_options: function(test) {
+  // simple no-compat build, one project
+  nocompat_options: function(test){
     test.expect(1);
 
     var actual = grunt.file.read('tmp/nocompat.js');
@@ -22,4 +24,34 @@ exports.packager = {
 
     test.done();
   },
+  // multi project build with dependency defined with `package/*`
+  multipackage: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/multipackage.js');
+    var expected = grunt.file.read('test/expected/multipackage.js');
+    test.equal(actual, expected, 'should be exact for multipackage build.');
+
+    test.done();
+  },
+  // multi project build with simple option `only: 'package'`
+  multipackage_partial_simple: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/multipackage_partial_simple.js');
+    var expected = grunt.file.read('test/expected/multipackage_partial_simple.js');
+    test.equal(actual, expected, 'should be exact for multipackage build with specified "only".');
+
+    test.done();
+  },
+  // multi project build with wildcard option `only: 'package/*'`
+  multipackage_partial_widcard: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/multipackage_partial_widcard.js');
+    var expected = grunt.file.read('test/expected/multipackage_partial_widcard.js');
+    test.equal(actual, expected, 'should be exact for multipackage build with specified "only".');
+
+    test.done();
+  }
 };


### PR DESCRIPTION
Improvment list:
- Now fully supports YAML dependency graphs
- Supports components referencing other components in the same package with the `/SomethingInThisPackage` or just `SomethingInThisPackage` convention
- Adds additional `--verbose` logging
- Adds support for `--show-packages` flag which will list all discovered packages and their components
- Adds support for configurations that use `only: ['PackageName/*']` wildcards to include entire packages
- Improves logging when a package is unable to be resolved in the dependency graph
- Added documentation for various flags and options
- Added specs for:
  - multi package
  - multi package with "only" in output options
  - multi package with wildcard `"package/*"` as output options
  - require string in format `package` and `/package`
- Added aditional `error` in cases when missing name in options for component path
