### PR TITLE
add noOutput and callback options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,25 @@ module.exports = function(grunt) {
         },
         src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
         dest: 'tmp/multipackage_partial_widcard.js'
-      }
+      },
+      callback: {
+        options: {
+          name: 'Test',
+		  callback: function(data){ grunt.file.write('tmp/callbackOutput.js', data);}
+        },
+        files: {
+          'tmp/all.js': 'test/fixtures/*.js',
+        }
+      },
+      noOutput: {
+        options: {
+          name: 'Test',
+		  noOutput: true
+        },
+        files: {
+          'tmp/noOutput.js': 'test/fixtures/*.js',
+        }
+      },
     },
 
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Default value: `grunt.util.linefeed`
 
 The delimeter to join all the source files together.
 
+#### options.callback
+Type: `Function`
+
+The function to be called when compile is done. The compiled content will passed as first parameter into the callback function.
+
+#### options.noOutput
+Type: `Boolean`
+
+If `true` no files will be written. Defaults to false.
+
 #### options.name
 Type: `String` or `Object`
 

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
   "name": "grunt-mootools-packager",
   "description": "Grunt task for MooTools Packager projects.",
-  "version": "0.3.0",
-  "homepage": "https://github.com/ibolmo/grunt-packager",
+  "version": "0.4.0",
+  "homepage": "https://github.com/ibolmo/grunt-mootools-packager",
   "author": {
     "name": "Olmo Maldonado",
     "email": "olmo.maldonado@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ibolmo/grunt-packager.git"
+    "url": "git://github.com/ibolmo/grunt-mootools-packager.git"
   },
   "bugs": {
-    "url": "https://github.com/ibolmo/grunt-packager/issues"
+    "url": "https://github.com/ibolmo/grunt-mootools-packager/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/ibolmo/grunt-packager/blob/master/LICENSE-MIT"
+      "url": "https://github.com/ibolmo/grunt-mootools-packager/blob/master/LICENSE-MIT"
     }
   ],
   "engines": {

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -177,9 +177,12 @@ module.exports = function(grunt) {
 
 			grunt.log.verbose.ok('successfully compiled', f.dest, 'with dependencies:', only || 'all');
 
+			if (options.noOutput) return;
 			grunt.file.write(f.dest, buffer);
 		});
 
+		var cb = options.callback;
+		if (cb) cb(buffer);
 	});
 
 };

--- a/test/packager_test.js
+++ b/test/packager_test.js
@@ -53,5 +53,24 @@ exports.packager = {
     test.equal(actual, expected, 'should be exact for multipackage build with specified "only".');
 
     test.done();
-  }
+  },
+  // option `callback`
+  callback: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/callbackOutput.js');
+    var expected = grunt.file.read('test/expected/all.js');
+    test.equal(actual, expected, 'should be exact same content for data ouputed via callback function');
+
+    test.done();
+  },
+  // option `noOutput
+  noOutput: function(test){
+    test.expect(1);
+
+    var exists = grunt.file.exists('tmp/noOutput.js');
+    test.equal(exists, false, 'file should not exist');
+
+    test.done();
+  },
 };


### PR DESCRIPTION
New options:
- `noOutput` - to make it not write any files
- `callback` - to pass the compiled data to a function and be used outside the packager

This is for website compiler, where compiled source can be passed directly to client/download and no files need to be written or read.
