### PR TITLE
add option.exclude

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,18 @@ module.exports = function(grunt) {
         src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
         dest: 'tmp/multipackage_partial_simple.js'
       },
+      multipackage_partial_exclude: {
+        options: {
+          only: 'ProjectB/*',
+		  exclude: ['ProjectA/*'],
+          name: {
+            ProjectB: 'test/fixtures/Project_B',
+            ProjectA: 'test/fixtures/Project_A'
+          }
+        },
+        src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
+        dest: 'tmp/multipackage_partial_exclude.js'
+      },
       multipackage_partial_widcard: {
         options: {
           only: 'ProjectB/*',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
       multipackage_partial_exclude: {
         options: {
           only: 'ProjectB/*',
-		  exclude: ['ProjectA/*'],
+          exclude: ['ProjectA/*'],
           name: {
             ProjectB: 'test/fixtures/Project_B',
             ProjectA: 'test/fixtures/Project_A'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,17 @@ module.exports = function(grunt) {
         src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
         dest: 'tmp/multipackage_partial_simple.js'
       },
+      multipackage_partial_simple_with_only_as_root: {
+        options: {
+          name: {
+            ProjectB: 'test/fixtures/Project_B',
+            ProjectA: 'test/fixtures/Project_A'
+          }
+        },
+        only: ['ProjectA/ProjectA.Secondary'],
+        src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
+        dest: 'tmp/multipackage_partial_simple_with_only_as_root.js'
+      },
       multipackage_partial_exclude: {
         options: {
           only: 'ProjectB/*',
@@ -67,6 +78,18 @@ module.exports = function(grunt) {
         },
         src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
         dest: 'tmp/multipackage_partial_exclude.js'
+      },
+      multipackage_partial_exclude_with_exclude_as_root: {
+        options: {
+          only: 'ProjectB/*',
+          exclude: ['ProjectA/*'],
+          name: {
+            ProjectB: 'test/fixtures/Project_B',
+            ProjectA: 'test/fixtures/Project_A'
+          }
+        },
+        src: ['test/fixtures/Project_A/*.js', 'test/fixtures/Project_B/*.js'],
+        dest: 'tmp/multipackage_partial_exclude_with_exclude_as_root.js'
       },
       multipackage_partial_widcard: {
         options: {
@@ -82,7 +105,7 @@ module.exports = function(grunt) {
       callback: {
         options: {
           name: 'Test',
-		  callback: function(data){ grunt.file.write('tmp/callbackOutput.js', data);}
+          callback: function(data){ grunt.file.write('tmp/callbackOutput.js', data);}
         },
         files: {
           'tmp/all.js': 'test/fixtures/*.js',
@@ -91,7 +114,7 @@ module.exports = function(grunt) {
       noOutput: {
         options: {
           name: 'Test',
-		  noOutput: true
+          noOutput: true
         },
         files: {
           'tmp/noOutput.js': 'test/fixtures/*.js',

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ grunt.initConfig({
 });
 ```
 
+#### options.exclude
+Type: `Array`
+
+The specific dependencies packages to exclude from the compilation.
+
 ### Other Usage Examples
 
 #### Default Options

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ grunt.initConfig({
       ],
       only: [
         'More/Form.Validator'
-      ]
+      ],
       dest: 'form.validator.js'
     },
     // all of the More package and its requirements
@@ -136,7 +136,7 @@ grunt.initConfig({
       ],
       only: [
         'More/*'
-      ]
+      ],
       dest: 'more.js'
     }
   },
@@ -146,7 +146,44 @@ grunt.initConfig({
 #### options.exclude
 Type: `Array`
 
-The specific dependencies packages to exclude from the compilation.
+The specific dependencies packages to exclude from the compilation. This allows you to build a file and exclude some portion of it's dependencies. Example:
+
+```js
+grunt.initConfig({
+  packager: {
+    options: {
+      name: {
+        Core: 'js/mootools-core',
+        More: 'js/mootools-more'
+      }
+    },
+    // build only Core
+    all: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+      ],
+      only: ['Core/*'],
+      dest: 'mootools-core.js'
+    },
+    // the Form.Validator component and its requirements from
+    // More, but none of the dependencies from Core
+    formValidator: {
+      src: [
+        'js/mootools-core/Source/**/*.js',
+        'js/mootools-more/Source/**/*.js'
+      ],
+      only: [
+        'More/Form.Validator'
+      ],
+      exclude: [
+        'Core/*'
+      ],
+      dest: 'form.validator.js'
+    }
+  },
+});
+```
+
 
 ### Other Usage Examples
 
@@ -178,3 +215,24 @@ grunt.initConfig({
   },
 });
 ```
+
+
+#### Build-Specific Options
+```js
+grunt.initConfig({
+  packager: {
+    options: {
+      name: 'Core'
+    },
+    all: {
+      'dest/mootools.js': 'Source/**.js',
+    },
+    allWithoutCompat: {
+      strip: '.*compat',
+      src: 'Source/**.js',
+      dest: 'mootools-no-compat.js'
+    },
+  },
+});
+```
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-mootools-packager",
   "description": "Grunt task for MooTools Packager projects.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "https://github.com/ibolmo/grunt-mootools-packager",
   "author": {
     "name": "Olmo Maldonado",

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -159,6 +159,8 @@ module.exports = function(grunt) {
 			}
 			// support global options.only as well as .only per build
 			var only = options.only || f.only;
+			// same deal with exclude option
+			var exclude = options.exclude || f.exclude;
 
 			grunt.log.verbose.writeln('compiling', f.dest, 'with dependencies:', only || 'all');
 
@@ -166,8 +168,8 @@ module.exports = function(grunt) {
 			(only ? toArray(only) : set).forEach(loadComponent);
 
 			// remove unwanted dependencies
-			if (options.exclude){
-				var toExclude = toArray(options.exclude); 
+			if (exclude){
+				var toExclude = toArray(exclude);
 				buffer = buffer.filter(function(def){
 					var shouldKeep = toExclude.filter(function(dependency){
 						var match = dependency.match(/([^\*]+)/);

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -165,6 +165,18 @@ module.exports = function(grunt) {
 			// load each component into the buffer list
 			(only ? toArray(only) : set).forEach(loadComponent);
 
+			// remove unwanted dependencies
+			if (options.exclude){
+				var toExclude = toArray(options.exclude); 
+				buffer = buffer.filter(function(def){
+					var shouldKeep = toExclude.filter(function(dependency){
+						var match = dependency.match(/([^\*]+)/);
+						return match ? def.key.indexOf(match[1]) != 0 : true;
+					});
+					return shouldKeep.length;
+				});
+			}
+
 			// convert the buffer into the actual source
 			buffer = buffer.map(function(def){ return def.source; }).join(options.separator);
 

--- a/test/expected/multipackage_partial_exclude.js
+++ b/test/expected/multipackage_partial_exclude.js
@@ -1,0 +1,17 @@
+/*
+---
+
+name: B part of ProjectA
+
+description: ProjectB, extending ProjectA
+
+requires: [ProjectA/ProjectA]
+
+provides: ProjectB
+
+...
+*/
+
+var projectB = function(){
+	return [projectA.name].concat('ProjectB');
+};

--- a/test/packager_test.js
+++ b/test/packager_test.js
@@ -5,7 +5,7 @@ var grunt = require('grunt');
 exports.packager = {
 
   // simple compat build, one project
-  default_options: function(test){ 
+  default_options: function(test){
     test.expect(1);
 
     var actual = grunt.file.read('tmp/all.js');
@@ -44,6 +44,16 @@ exports.packager = {
 
     test.done();
   },
+  // multi project build with simple option `only: 'package'`
+  multipackage_partial_simple_with_only_as_root: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/multipackage_partial_simple_with_only_as_root.js');
+    var expected = grunt.file.read('test/expected/multipackage_partial_simple.js');
+    test.equal(actual, expected, 'should be exact for multipackage build with specified "only".');
+
+    test.done();
+  },
   // multi project build with wildcard option `only: 'package/*'`
   multipackage_partial_widcard: function(test){
     test.expect(1);
@@ -59,6 +69,16 @@ exports.packager = {
     test.expect(1);
 
     var actual = grunt.file.read('tmp/multipackage_partial_exclude.js');
+    var expected = grunt.file.read('test/expected/multipackage_partial_exclude.js');
+    test.equal(actual, expected, 'should be exact for multipackage build without specified excluded components.');
+
+    test.done();
+  },
+  // multi project build with wildcard option `exclude: 'package/*'`
+  multipackage_partial_exclude_with_exclude_as_root: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/multipackage_partial_exclude_with_exclude_as_root.js');
     var expected = grunt.file.read('test/expected/multipackage_partial_exclude.js');
     test.equal(actual, expected, 'should be exact for multipackage build without specified excluded components.');
 

--- a/test/packager_test.js
+++ b/test/packager_test.js
@@ -54,6 +54,16 @@ exports.packager = {
 
     test.done();
   },
+  // multi project build with wildcard option `exclude: 'package/*'`
+  multipackage_partial_exclude: function(test){
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/multipackage_partial_exclude.js');
+    var expected = grunt.file.read('test/expected/multipackage_partial_exclude.js');
+    test.equal(actual, expected, 'should be exact for multipackage build without specified excluded components.');
+
+    test.done();
+  },
   // option `callback`
   callback: function(test){
     test.expect(1);


### PR DESCRIPTION
add option.exclude so we can exclude dependencies in Gruntfile. 

A example would be: 
If compiling More, have the option to exclude Core by adding:

`exclude: ['Core/*']`
